### PR TITLE
Setup all the attributes, descriptions, add NASA API, request and merge data 

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { clsx } from "clsx";
-import { ILocation, TabName } from "../types";
-import { kInitialDimensions, kVersion, kPluginName, kDefaultOnAttributes } from "../constants";
+import { TabName } from "../types";
+import { kInitialDimensions, kVersion, kPluginName } from "../constants";
 import { initializePlugin, selectSelf } from "@concord-consortium/codap-plugin-api";
-import { useCodapData } from "../hooks/useCodapData";
 import { LocationTab } from "./location-tab";
 import { AboutTab } from "./about-tab";
 import { Header } from "./header";
@@ -12,12 +11,6 @@ import "./app.scss";
 
 export const App: React.FC = () => {
   const [activeTab, setActiveTab] = useState<TabName>("location");
-  const [latitude, setLatitude] = useState("");
-  const [longitude, setLongitude] = useState("");
-  const [locationSearch, setLocationSearch] = useState<string>("");
-  const [selectedAttrs, setSelectedAttributes] = useState<string[]>(kDefaultOnAttributes);
-
-  const { getDayLengthData, dataContext } = useCodapData();
 
   useEffect(() => {
     const initialize = async () => {
@@ -31,7 +24,6 @@ export const App: React.FC = () => {
         console.error("Failed to initialize plugin, error:", e);
       }
     };
-
     initialize();
   }, []);
 
@@ -39,34 +31,11 @@ export const App: React.FC = () => {
     setActiveTab(tab);
   };
 
-  const handleGetDataClick = async () => {
-    const name = locationSearch || `(${latitude}, ${longitude})`;
-    const currentLocation: ILocation = { name, latitude: Number(latitude), longitude: Number(longitude) };
-    if (!latitude || !longitude) return;
-
-    // if the location does not already exist, and we have params, get the data
-    await getDayLengthData(currentLocation, selectedAttrs);
-  };
-
   return (
     <div className="app" onClick={selectSelf}>
-      <Header
-        activeTab={activeTab}
-        onTabClick={handleTabClick}
-      />
+      <Header activeTab={activeTab} onTabClick={handleTabClick} />
       <div className={clsx("tab-content", { active: activeTab === "location" })}>
-        <LocationTab
-          latitude={latitude}
-          longitude={longitude}
-          locationSearch={locationSearch}
-          selectedAttrs={selectedAttrs}
-          dataContext={dataContext}
-          setLatitude={setLatitude}
-          setLongitude={setLongitude}
-          setLocationSearch={setLocationSearch}
-          setSelectedAttributes={setSelectedAttributes}
-          handleGetDataClick={handleGetDataClick}
-        />
+        <LocationTab />
       </div>
       <div className={clsx("tab-content", { active: activeTab === "glossary" })}>
         <AboutTab />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,7 +49,7 @@ export const kChildCollectionAttributes: IAttribute[] = [
   },
   {
     name: "Month",
-    title: "Moth",
+    title: "Month",
     type: "categorical",
     formula: "monthName(Date)"
   },
@@ -157,7 +157,7 @@ export const kChildCollectionAttributes: IAttribute[] = [
     title: "Max surface temperature",
     type: "numeric",
     unit: "°C",
-    description: "The daily maximum temperature at the Earth’s surface for a specific location Also known as Earth’s “skin temperature.”",
+    description: "The daily maximum temperature at the Earth’s surface for a specific location. Also known as Earth’s “skin temperature.”",
     NASAParamName: "TS_MAX",
     category: "Temperature"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,8 @@
+import { IAttribute } from "./types";
+
 export const kPluginName = "NASA: Earth, Air, and Water";
 export const kVersion = "0.0.1";
-export const kDataContextName = "DayLengthPluginData";
+export const kDataContextName = "NASAPluginData";
 export const kInitialDimensions = {
   width: 360,
   height: 541
@@ -17,121 +19,182 @@ export const kGeonamesUser = "codap";
 export const kDefaultMaxRows = 4;
 
 export const kParentCollectionName = "Locations";
-export const kChildCollectionName = "Daylight Info";
+export const kChildCollectionName = "NASA Info";
 
 export const kAdjustSpringForwardOutlier = false;
 
 export const kParentCollectionAttributes = [
   {
-    name: "latitude",
-    type: "numeric"
+    name: "Latitude",
+    type: "numeric",
+    unit: "°"
   },
   {
-    name: "longitude",
-    type: "numeric"
+    name: "Longitude",
+    type: "numeric",
+    unit: "°"
   },
   {
-    name: "location",
+    name: "Location",
     type: "categorical"
   }
 ];
 
-export const kChildCollectionAttributes = [
+export const kChildCollectionAttributes: IAttribute[] = [
   {
-    name: "date",
+    name: "Date",
     title: "Date",
     type: "date",
-    hasToken: true,
     precision: "day",
-    description: "Date"
   },
   {
-    name: "dayOfYear",
-    title: "Day of year",
-    type: "numeric",
-    hasToken: false,
-    hidden: true,
-    description: "Day of year"
+    name: "Month",
+    title: "Moth",
+    type: "categorical",
+    formula: "monthName(Date)"
   },
   {
-    name: "Day length",
-    title: "Day length",
-    type: "numeric",
-    hasToken: true,
-    unit: "hours",
-    description: "Day length in hours"
-  },
-  {
-    name: "rawSunrise",
-    title: "rawSunrise",
-    type: "date",
-    hasToken: true,
-    hidden: true,
-    precision: "seconds",
-    description: "sunrise as date object"
-  },
-  {
-    name: "rawSunset",
-    title: "rawSunset",
-    type: "date",
-    hasToken: false,
-    hidden: true,
-    precision: "seconds",
-    description: "sunset as date object"
-  },
-  {
-    name: "Sunrise",
-    title: "Sunrise",
-    type: "numeric",
-    hasToken: false,
-    unit: "decimal hours",
-    formula: "hours(rawSunrise)+minutes(rawSunrise)/60",
-    description: "time in decimal hours"
-  },
-  {
-    name: "Sunset",
-    title: "Sunset",
-    type: "numeric",
-    hasToken: false,
-    unit: "decimal hours",
-    formula: "hours(rawSunset)+minutes(rawSunset)/60",
-    description: "time in decimal hours"
-  },
-  {
-    name: "Sunlight angle",
-    title: "Sunlight angle",
-    type: "numeric",
-    hasToken: false,
-    unit: "°",
-    description: "angle in degrees of sunlight at solar noon"
-  },
-  {
-    name: "Solar intensity",
-    title: "Solar intensity",
-    type: "numeric",
-    hasToken: false,
-    unit: "W/㎡",
-    description: "intensity of solar energy in watts per square meter at solar noon, disregarding all atmospheric effects"
+    name: "Year",
+    title: "Year",
+    type: "categorical",
+    formula: "year(Date)",
   },
   {
     name: "Season",
     title: "Season",
     type: "categorical",
-    hasToken: false
+    description: "Seasons are determined by the dates of the spring and fall equinoxes and the summer and winter solstices."
   },
   {
-    name: "calcId",
-    title: "calcId",
-    type: "categorical",
-    hasToken: false,
+    name: "Elevation",
+    title: "Elevation",
+    type: "numeric",
+    unit: "meter"
+  },
+  // -- Sunlight Category --
+  {
+    name: "Length of day",
+    title: "Length of day",
+    type: "numeric",
+    unit: "hours",
+    description: "Number of hours of sunlight in decimal time.",
+    category: "Sunlight"
+  },
+  {
+    name: "rawSunrise",
+    title: "rawSunrise",
+    type: "date",
     hidden: true,
-    description: "unique identifier for each location on a day - concatenation of latitude, longitude, and dayOfYear",
-    formula: "latitude + ',' + longitude + ',' + dayOfYear"
+    precision: "seconds",
+    description: "Sunrise as date object.",
+    category: "Sunlight"
+  },
+  {
+    name: "rawSunset",
+    title: "rawSunset",
+    type: "date",
+    hidden: true,
+    precision: "seconds",
+    description: "Sunset as date object.",
+    category: "Sunlight"
+  },
+  {
+    name: "Sunrise",
+    title: "Sunrise",
+    type: "numeric",
+    unit: "decimal hours",
+    formula: "hours(rawSunrise)+minutes(rawSunrise)/60",
+    description: "The local time of sunrise in decimal time.",
+    category: "Sunlight"
+  },
+  {
+    name: "Sunset",
+    title: "Sunset",
+    type: "numeric",
+    unit: "decimal hours",
+    formula: "hours(rawSunset)+minutes(rawSunset)/60",
+    description: "The local time of sunset in decimal time.",
+    category: "Sunlight"
+  },
+  {
+    name: "Sunlight angle",
+    title: "Sunlight angle",
+    type: "numeric",
+    unit: "°",
+    description: "Angle at which sunlight hits the earth at noon each day (degrees).",
+    category: "Sunlight"
+  },
+  {
+    name: "UV Index",
+    title: "UV Index",
+    type: "numeric",
+    unit: "",
+    description: "The ultraviolet radiation exposure index (UV Index) is a scale that measures the amount of UV radiation reaching the Earth's surface. It provides a daily forecast of the expected risk of overexposure to the sun.",
+    NASAParamName: "ALLSKY_SFC_UV_INDEX",
+    category: "Sunlight"
+  },
+  {
+    name: "Solar intensity",
+    title: "Solar intensity",
+    type: "numeric",
+    unit: "W/㎡",
+    description: "An estimate of the amount of energy from the Sun traveling downward toward the surface of the Earth at noon each day.",
+    NASAParamName: "CLRSKY_SFC_SW_DWN",
+    category: "Sunlight"
+  },
+  // -- Temperature Category --
+  {
+    name: "Max air temperature",
+    title: "Max air temperature",
+    type: "numeric",
+    unit: "°C",
+    description: "Daily maximum air temperature at 2 meters above the surface of the earth.",
+    NASAParamName: "T2M_MAX",
+    category: "Temperature"
+  },
+  {
+    name: "Max surface temperature",
+    title: "Max surface temperature",
+    type: "numeric",
+    unit: "°C",
+    description: "The daily maximum temperature at the Earth’s surface for a specific location Also known as Earth’s “skin temperature.”",
+    NASAParamName: "TS_MAX",
+    category: "Temperature"
+  },
+  // -- Water Availability Category --
+  {
+    name: "Precipitation",
+    title: "Precipitation",
+    type: "numeric",
+    unit: "mm/day",
+    description: "Total precipitation reaching Earth’s surface for the day (includes snow).",
+    NASAParamName: "PRECTOTCORR",
+    category: "Water Availability"
+  },
+  {
+    name: "Daytime clouds",
+    title: "Daytime clouds",
+    type: "numeric",
+    unit: "%",
+    description: "The average percentage of cloud cover over the course of the day (during daylight).",
+    NASAParamName: "CLOUD_AMT_DAY",
+    category: "Water Availability"
+  },
+  {
+    name: "Soil moisture",
+    title: "Soil moisture",
+    type: "numeric",
+    unit: "",
+    description: "Amount of soil moisture from 0% water free to 100% saturated.",
+    NASAParamName: "GWETPROF",
+    category: "Water Availability"
   }
 ];
 
+export const kUsedNASAParams = kChildCollectionAttributes.filter(attr => attr.NASAParamName) as (IAttribute & { NASAParamName: string })[];
+
 export const kDefaultOnAttributes = [
-  "date", "Day length"
+  "date", "Length of day"
 ];
 
 export const kDateWithTimeFormats = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,12 +13,12 @@ export interface ILocation {
 export interface DaylightCalcOptions {
   latitude: number;
   longitude: number;
-  year: number;
+  startDate: string;
+  endDate: string;
 }
 
 export interface DaylightInfo {
   day: string;          // read into CODAP as an ISO date
-  dayOfYear: number;
   rawSunrise: string;   // read into CODAP as an ISO date
   rawSunset: string;    // read into CODAP as an ISO date
   dayLength: number;
@@ -33,3 +33,22 @@ export interface GeoNameSearchOptions {
 }
 
 export type TabName = "location" | "glossary" | "about";
+
+// Data types
+
+export type NASAParameter = "ALLSKY_SFC_UV_INDEX" | "CLRSKY_SFC_SW_DWN" | "T2M_MAX" | "TS_MAX" | "PRECTOTCORR" | "CLOUD_AMT_DAY" | "GWETPROF";
+
+export type AttributeCategory = "Sunlight" | "Temperature" | "Water Availability";
+
+export interface IAttribute {
+  name: string;
+  title: string;
+  type: string;
+  unit?: string;
+  precision?: string;
+  formula?: string;
+  description?: string;
+  hidden?: boolean;
+  NASAParamName?: NASAParameter;
+  category?: AttributeCategory;
+}

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -107,14 +107,14 @@ export function getMinutesSinceMidnight(time: Dayjs): number {
 }
 
 export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {
-  const { latitude, longitude, year } = options;
+  const { latitude, longitude, startDate, endDate } = options;
   const results: DaylightInfo[] = [];
 
   const timeZone = tzlookup(latitude, longitude);
-  let currentDay = dayjs.tz(`${year}-01-01`, timeZone).startOf("day");
-  const endOfYear = dayjs.tz(`${year + 1}-01-01`, timeZone).startOf("day");
+  let currentDay = dayjs.tz(startDate, timeZone).startOf("day");
+  const endDay = dayjs.tz(endDate, timeZone).startOf("day");
 
-  while (currentDay.isBefore(endOfYear)) {
+  while (currentDay.isBefore(endDay)) {
     const noonDate = currentDay.hour(12).toDate();
     const utcSunrise = dayjs.utc(getSunrise(latitude, longitude, noonDate));
     const utcSunset = dayjs.utc(getSunset(latitude, longitude, noonDate));
@@ -146,7 +146,8 @@ export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {
     else {
       finalDayLength = getDayLength(localSunriseObj, localSunsetObj);
       // Optional adjustment of outlier on spring forward day for some timezones
-      if (kAdjustSpringForwardOutlier){
+      if (kAdjustSpringForwardOutlier) {
+        const year = currentDay.year();
         const isSpringForward = localSunriseObj.utcOffset() < localSunsetObj.utcOffset();
         if (hasDST(latitude, longitude, year) && isSpringForward) finalDayLength -= 1;
       }
@@ -154,7 +155,6 @@ export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {
 
     const record: DaylightInfo = {
       day: currentDay.format(kDateFormats.asLocalISODate),
-      dayOfYear: currentDay.dayOfYear(),
       rawSunrise: localSunriseObj.format(kDateWithTimeFormats.asLocalISOWithTZOffset),
       rawSunset: localSunsetObj.format(kDateWithTimeFormats.asLocalISOWithTZOffset),
       dayLength: finalDayLength,

--- a/src/utils/nasa-api.test.ts
+++ b/src/utils/nasa-api.test.ts
@@ -1,0 +1,11 @@
+import { dateToAPIDateFormat } from "./nasa-api";
+
+describe("NASA API", () => {
+  describe("dateToAPIDateFormat", () => {
+    it("should return a string in the format YYYYMMDD", () => {
+      expect(dateToAPIDateFormat(new Date("2021-01-01"))).toBe("20210101");
+      expect(dateToAPIDateFormat(new Date("2021-12-31"))).toBe("20211231");
+      expect(dateToAPIDateFormat(new Date("2021-05-05"))).toBe("20210505");
+    });
+  });
+});

--- a/src/utils/nasa-api.ts
+++ b/src/utils/nasa-api.ts
@@ -1,0 +1,58 @@
+import { kUsedNASAParams } from "../constants";
+
+const baseURL = "https://power.larc.nasa.gov/api/temporal/daily/point";
+
+const config = {
+  // Community parameter affects the units of the data.
+  // ag=Agroclimatology
+  // sb=Sustainable Buildings
+  // re=Renewable Energy
+  // sb seems to be the most useful for our case, as it sets the units of CLRSKY_SFC_SW_DWN to W/m^2 that was requested by PIs.
+  // You can check the units for each community value in the API documentation: https://power.larc.nasa.gov/
+  // (go to Resources and look for your parameter)
+  community: "sb",
+  parameters: kUsedNASAParams.map(attr => attr.NASAParamName).join(","),
+  format: "json",
+  "time-standard": "lst"
+}
+
+export const dateToAPIDateFormat = (date: string | Date) => {
+  if (typeof date === "string") {
+    date = new Date(date);
+  }
+  return date.toISOString().split("T")[0].replace(/-/g, "");
+};
+
+export async function fetchNASAData(latitude: number, longitude: number, startDate: string, endDate: string) {
+  const queryParams = new URLSearchParams({
+    ...config,
+    start: dateToAPIDateFormat(startDate),
+    end: dateToAPIDateFormat(endDate),
+    latitude: latitude.toString(),
+    longitude: longitude.toString(),
+  });
+
+  const url = `${baseURL}?${queryParams.toString()}`;
+
+  const response = await fetch(url);
+  const json = await response.json();
+  if (!response.ok) {
+    console.error("NASA POWER API Error:", response.statusText, json, json.messages.join(", "));
+    throw new Error(json.messages[0]);
+  }
+
+  return json;
+}
+
+export function getNASAAttributeValues(NASAResponse: any, day: string): Record<string, number> {
+  const { parameter: values } = NASAResponse.properties;
+  const formattedDate = dateToAPIDateFormat(day);
+
+  return kUsedNASAParams.reduce((result: Record<string, number>, attr) => {
+    const value = values[attr.NASAParamName]?.[formattedDate];
+    if (value !== undefined) {
+      result[attr.name] = value;
+    }
+    return result;
+  }, {});
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/188181516

This PR adds the main functionality of the plugin: it calculates day length data, requests NASA data, merges them, and sends the results to CODAP. I’ve also added error handling for cases where NASA returns an error, which could be useful for date range issues (as they support only years from 1981 onward), or for any other new errors that may show up over time.